### PR TITLE
MBean operation and attribute names can clobber MBeanProxy methods of the same name

### DIFF
--- a/lib/jmx.rb
+++ b/lib/jmx.rb
@@ -154,8 +154,12 @@ module JMX
     private
 
     def safe_define_method(method_name, &block)
-      method_name = "mbean_#{method_name}" if respond_to?(method_name) || method_name == 'initialize'
-      self.class.__send__(:define_method, method_name, &block)
+      @@defined_methods ||= Hash.new { |h, k| h[k] = [] }
+      unless @@defined_methods[self.class.name].include?(method_name)
+        @@defined_methods[self.class.name] << method_name
+        method_name = "mbean_#{method_name}" if respond_to?(method_name) || method_name == 'initialize'
+        self.class.__send__(:define_method, method_name, &block)
+      end
     end
     
     # Define ruby friendly methods for attributes.  For odd attribute names or names


### PR DESCRIPTION
This change prevents clobbering instance methods that already exist on the
MBeanProxy class. I ran into it when working with an mbean that exposed
an 'initialize' operation, which made it impossible to instantiate an
instance of the MBeanProxy subclass for that mbean a second time.

A side-effect of this change is you'll end up with a bunch of 'mbean_*'
methods defined after proxying a two mbeans of the same class.
