### PR TITLE
Server and registry are now opts to simple_server

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ You can also create your own MBeans and register them as well:
      end
    end
 
-   my)server = JMX::MBeanServer.new
+   my_server = JMX::MBeanServer.new
    my_server_connector = JMX.simple_server(server: server)
 
    dyna = MyDynamicMBean.new("domain.MySuperBean", "Heh")

--- a/README.md
+++ b/README.md
@@ -35,9 +35,12 @@ You can also create your own MBeans and register them as well:
      end
    end
 
+   server = JMX::MBeanServer.new
+   my_server_connector = JMX.simple_server(server: server)
+
    dyna = MyDynamicMBean.new("domain.MySuperBean", "Heh")
-   domain = my_server.default_domain
-   my_server.register_mbean dyna, "#{@domain}:type=MyDynamicMBean"
+   domain = server.default_domain
+   server.register_mbean dyna, "#{domain}:type=MyDynamicMBean"
 ```
 
 ## REQUIREMENTS:

--- a/README.md
+++ b/README.md
@@ -35,12 +35,12 @@ You can also create your own MBeans and register them as well:
      end
    end
 
-   server = JMX::MBeanServer.new
+   my)server = JMX::MBeanServer.new
    my_server_connector = JMX.simple_server(server: server)
 
    dyna = MyDynamicMBean.new("domain.MySuperBean", "Heh")
-   domain = server.default_domain
-   server.register_mbean dyna, "#{domain}:type=MyDynamicMBean"
+   domain = my_server.default_domain
+   my_server.register_mbean dyna, "#{domain}:type=MyDynamicMBean"
 ```
 
 ## REQUIREMENTS:

--- a/lib/jmx.rb
+++ b/lib/jmx.rb
@@ -36,8 +36,9 @@ module JMX
   def self.simple_server(opts = {})
     port = opts[:port] || 8686
     url_path = opts[:url_path] || "/jmxrmi"
+    server = opts[:server] || JMX::MBeanServer.new
     url = "service:jmx:rmi:///jndi/rmi://localhost:#{port}#{url_path}"
-    $registry = RMIRegistry.new port
+    $registry = opts[:registry] || RMIRegistry.new(port)
     @connector = JMX::MBeanServerConnector.new(url, JMX::MBeanServer.new).start
   end
 end


### PR DESCRIPTION
This patch allows a user to pass into JMX.simple_server a predefined
server and registry.

It also updates the sample code in the README to be executable.
Previously it did not work (due to server not being accessible).