### PR TITLE
Scope const_defined? & const_get to the parent

### DIFF
--- a/lib/jmx/mbean_proxy.rb
+++ b/lib/jmx/mbean_proxy.rb
@@ -29,8 +29,8 @@ module JMX
     def self.generate(server, object_name)
       parent, class_name = MBeans.parent_for object_name.info(server).class_name
 
-      if parent.const_defined? class_name
-        proxy = parent.const_get(class_name)
+      if parent.const_defined? class_name, false
+        proxy = parent.const_get(class_name, false)
       else
         proxy = Class.new MBeanProxy
         parent.const_set class_name, proxy

--- a/lib/jmx/mbeans.rb
+++ b/lib/jmx/mbeans.rb
@@ -16,10 +16,10 @@ module JMX
         return [parent, segment] if segment =~ /^[A-Z]/
 
         segment.capitalize!
-        unless parent.const_defined? segment
+        unless parent.const_defined? segment, false
           parent.const_set segment, Module.new
         else 
-          parent.const_get segment
+          parent.const_get segment, false
         end
       end
 


### PR DESCRIPTION
Otherwise, a top-level constant can be found instead, leading to
erroneous behavior.

I haven't kept up with Ruby, so I don't know if the default behavior of `const_defined?`/`const_get` have changed to trigger this now, but these changes seem to fix https://github.com/torquebox/backstage/issues/36

Let me know how wrong I am.
